### PR TITLE
Feature/DO-1447 LaunchConfig Cleanup

### DIFF
--- a/launchconfigcleanup/README.md
+++ b/launchconfigcleanup/README.md
@@ -1,0 +1,52 @@
+# launchconfigcleanup
+
+AWS Lambda function to cleanup autoscaling LaunchConfiguration resources if an
+account has reached it's limit. Or to explicitly clean them up.
+
+## Requirements
+
+The script depends on [boto3](http://boto3.readthedocs.org/en/latest/).  It is provided by AWS lambda at runtime but the library is needed to execute the `upload.py` script locally.
+
+## Installation
+
+Set your AWS token via environment variables:
+
+```bash
+$ export AWS_DEFAULT_REGION=<region>
+$ export AWS_ACCESS_KEY_ID=<XXXXXXXXXXXXXXXX>
+$ export AWS_SECRET_ACCESS_KEY=<XXXXXXXXXXXXXXXX>
+```
+
+Run the `upload.py` script to setup IAM roles, policies, and lambda function for execution.
+
+```bash
+$ python upload.py launchconfigcleanup
+```
+
+## Usage
+
+### Dry Run
+
+There is no DryRun supported by this API.
+
+### CLI Usage
+
+```sh
+launchconfigcleanup - Assists in cleaning up unused LaunchConfigurations
+
+Usage: launchconfigcleanup.py [options]
+
+Options:
+    -a, --minage DAYS   Minimum number of days a LaunchConfiguration must be
+                        to be considered a deletion candidate.
+
+    -D, --delete        Delete a candidate if one is present
+
+    -n, --maxlcs NUM    Maximum number of LaunchConfigurations allowed in the
+                        AWS account. A candidate will only be presented if the
+                        account is at its limit.
+```
+
+## Scheduling
+
+Scheduled execution must be set up manually in the lambda console until boto3 adds support.

--- a/launchconfigcleanup/launchconfigcleanup.json
+++ b/launchconfigcleanup/launchconfigcleanup.json
@@ -1,0 +1,16 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAccountLimits",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLaunchConfigurations",
+        "autoscaling:DeleteLaunchConfiguration"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/launchconfigcleanup/launchconfigcleanup.py
+++ b/launchconfigcleanup/launchconfigcleanup.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+"""
+
+launchconfigcleanup - Assists in cleaning up unused LaunchConfigurations
+
+Usage: launchconfigcleanup.py [options]
+
+Options:
+    -D, --delete        Delete a candidate if one is present
+    -n, --maxlcs NUM    Maximum number of LaunchConfigurations allowed in the
+                        AWS account. A candidate will only be presented if the
+                        account is at its limit.
+"""
+
+from __future__ import print_function
+
+import boto3
+import logging
+from botocore.exceptions import ClientError
+
+
+log = logging.getLogger(__name__)
+"""Create a logger"""
+
+DEFAULT_LAUNCHCONFIGURATION_LIMIT = 100
+"""Max number of LaunchConfigurations allowed in AWS account"""
+
+
+def get_all_launchconfigurations(asg_client):
+    """
+    Generator to find all LaunchConfigurations
+    """
+    lc_pager = asg_client.get_paginator('describe_launch_configurations')
+    lc_iter = lc_pager.paginate()
+    for lc_page in lc_iter:
+        for lc in lc_page['LaunchConfigurations']:
+            yield lc
+
+
+def get_inuse_launchconfigurations(asg_client):
+    """
+    Generator to find LaunchConfigurations in-use by ASGs
+
+    :param asg_client: boto3 autoscaling client
+    :type asg_client: botocore.client.AutoScaling
+    """
+    asg_pager = asg_client.get_paginator('describe_auto_scaling_groups')
+    asg_iter = asg_pager.paginate()
+    for asg_page in asg_iter:
+        for asg in asg_page['AutoScalingGroups']:
+            yield asg['LaunchConfigurationName']
+
+
+def get_launchconfigurations_delete_candidate(asg_client,
+        lc_limit=DEFAULT_LAUNCHCONFIGURATION_LIMIT):
+    """
+    Return the name of a LaunchConfiguration to delete if space is needed
+
+    :param asg_client: boto3 autoscaling client
+    :type asg_client: botocore.client.AutoScaling
+    :param lc_limit: Max number of LaunchConfigurations allowed in account
+    :type lc_limit: int
+    """
+    all_lcs = [lc for lc in get_all_launchconfigurations(asg_client)]
+
+    if len(all_lcs) < lc_limit:
+        # No LC needs to be deleted
+        log.info("{lc} < {limit}, no LaunchConfiguration deletion needed".format(
+            lc=len(all_lcs),
+            limit=lc_limit))
+        return None
+
+    log.warning("At LaunchConfiguration limit! ({limit})".format(
+        limit=lc_limit))
+
+    # Find LCs that are in-use
+    used_lcs = [lc_name for lc_name in get_inuse_launchconfigurations(asg_client)]
+    log.debug("Found {} LaunchConfigurations in-use".format(len(used_lcs)))
+
+    # Determine unused LCs
+    unused = [lc for lc in all_lcs if lc['LaunchConfigurationName'] not in used_lcs]
+    log.debug("Found {} LaunchConfigurations unused".format(len(unused)))
+
+    return sorted(unused, key=lambda k: k['CreatedTime'])[0]
+
+
+if __name__ == '__main__':
+    import json
+    import sys
+    from docopt import docopt
+
+    # Setup logging
+    logging.basicConfig(**{
+        'level': logging.INFO,
+        'format': '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
+    })
+
+    # Parse CLI arguments
+    args = docopt(__doc__, version='dev')
+
+    do_delete = args['--delete']
+    max_lcs = int(args['--maxlcs'] or DEFAULT_LAUNCHCONFIGURATION_LIMIT)
+
+    # Create boto client for ASG API
+    client = boto3.client('autoscaling')
+
+    # Find a deletion candidate
+    candidate = get_launchconfigurations_delete_candidate(
+        client,
+        max_lcs)
+
+    # If no candidate is present, exit
+    if candidate is None:
+        log.warning("No deletion candidate found")
+        sys.exit(0)
+
+    # Convert the candidates CreatedTime field to a string for serialization
+    if 'CreatedTime' in candidate:
+        candidate.update({
+            'CreatedTime': candidate['CreatedTime'].isoformat()
+        })
+
+    log.info("Candidate:")
+    log.info(json.dumps(
+        candidate,
+        indent=4,
+        separators=(',', ': ')))
+
+    if do_delete:
+        # Execution the deletion
+        log.info("Attempting to delete the LaunchConfiguration")
+
+        try:
+            client.delete_launch_configuration(
+                LaunchConfigurationName=candidate['LaunchConfigurationName'])
+
+        except ClientError as e:
+            log.critical("Failed to delete LaunchConfiguration", exc_info=True)
+            sys.exit(254)
+
+        except Exception as e:
+            log.critical("Unknown failure!", exc_info=True)
+            sys.exit(254)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
 
     extras_require = {
         'dev': [
+            'docopt',
             'terminaltables',
         ],
     }


### PR DESCRIPTION
- Removes oldest unused LaunchConfiguration only if the account is at it's limit (or a different arbitrary limit is specified)
- Only removes if over a minimum age (default: 5 days)
- Supports being executed via CLI or Lambda