### PR TITLE
Send Reservation Report via SNS Instead of SES

### DIFF
--- a/reservedinstancecheck/reservedinstancecheck.json
+++ b/reservedinstancecheck/reservedinstancecheck.json
@@ -7,8 +7,7 @@
       "Action": [
         "ec2:DescribeInstances",
         "ec2:DescribeReservedInstances",
-        "ses:SendEmail",
-        "ses:SendRawEmail"
+        "sns:Publish"
       ],
       "Resource": "*"
     }

--- a/reservedinstancecheck/reservedinstancecheck.py
+++ b/reservedinstancecheck/reservedinstancecheck.py
@@ -383,6 +383,13 @@ class ReservationChecker(object):
         return self._unused
 
 
+def get_aws_account_id():
+    """ Returns the AWS account Id
+    """
+    return boto3.client('sts').get_caller_identity() \
+        .get('Account')
+
+
 def lambda_handler(event, context):
     """
     Assesses instance reservations and produces a report on them

--- a/reservedinstancecheck/reservedinstancecheck.py
+++ b/reservedinstancecheck/reservedinstancecheck.py
@@ -403,6 +403,8 @@ def lambda_handler(event, context):
     """
     Assesses instance reservations and produces a report on them
     """
+    import json
+
     event_settings = copy(LAMBDA_DEFAULTS)
     event_settings.update(event)
 
@@ -453,6 +455,10 @@ def lambda_handler(event, context):
                 account=get_aws_account_id(),
                 region=event_settings['Region'] or sns.meta.region_name),
             Message=report_text)
+        print(json.dumps(resp,
+                         indent=4,
+                         separators=(',', ': '),
+                         sort_keys=False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Migrates from using [SES](https://aws.amazon.com/ses/) to [SNS](https://aws.amazon.com/sns/) instead

    This helps avoid constraints when SES is not setup properly within an account. Such as not having verified domains and/or addresses

- Added functions to find AWS account alias and/or account id to be added into SNS message subject