### PR TITLE
Add ElastiCache Event Filtering to VictorOps

### DIFF
--- a/elasticache_alerts/README.md
+++ b/elasticache_alerts/README.md
@@ -1,0 +1,62 @@
+# elasticache_alerts
+
+Script that ingests SNS messages from ElastiCache, filters out known
+or insignificant events, and relays the remaining events to a separate
+SNS topic.
+
+This allows for alerting to significant/critical events.
+
+## Requirements
+
+The script depends on [boto3](http://boto3.readthedocs.org/en/latest/).  It is
+provided by AWS lambda at runtime but the library is needed to execute the
+`upload.py` script locally.
+
+## Installation
+
+Set your AWS token via environment variables:
+
+```bash
+$ export AWS_DEFAULT_REGION=<region>
+$ export AWS_ACCESS_KEY_ID=<XXXXXXXXXXXXXXXX>
+$ export AWS_SECRET_ACCESS_KEY=<XXXXXXXXXXXXXXXX>
+```
+
+Run the `upload.py` script to setup IAM roles, policies, and lambda function for execution.
+
+```bash
+$ python upload.py elasticache_alerts
+```
+
+There are several facets of installation that _are not_ addressed by this script:
+
+- Creation of SNS topic
+- Configuration of ElastiCache to use the SNS topic
+- Creation of SNS topic to relay important messages to
+- Configuration of `RELAY_TOPIC` and `RELAY_MESSAGES` environmental variables
+for Lambda execution.
+
+## Usage
+
+### Dry Run
+
+There is no DryRun supported by this API.
+
+### Lambda Settings
+
+| Name | Descrption |
+| ---- | ---------- |
+| `RELAY_TOPIC` | SNS ARN to relay important messages to |
+| `RELAY_MESSAGES` | List of message types to relay |
+
+Example `RELAY_MESSAGES`:
+
+```
+"elasticache:addcachenodecomplete","elasticache:cacheclusterparameterschanged","elasticache:cacheclusterprovisioningcomplete","elasticache:cacheclusterscalingcomplete","elasticache:cacheclustersecuritygroupmodified","elasticache:cachenodereplacecomplete","elasticache:createreplicationgroupcomplete","elasticache:deletecacheclustercomplete","elasticache:removecachenodecomplete","elasticache:replicationgroupscalingcomplete","elasticache:snapshotcomplete"
+```
+
+**Note:** `RELAY_MESSAGES` must be compliant input for a JSON list and each
+message type should be in all lowercase.
+
+A full listing of events can be found in
+[Event Notifications and Amazon SNS](http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/ElastiCacheSNS.html).

--- a/elasticache_alerts/elasticache_alerts.json
+++ b/elasticache_alerts/elasticache_alerts.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "",
+            "Effect": "Allow",
+            "Action": [
+                "sns:Publish"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:*"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        }
+    ]
+}

--- a/elasticache_alerts/elasticache_alerts.py
+++ b/elasticache_alerts/elasticache_alerts.py
@@ -1,0 +1,75 @@
+from __future__ import print_function
+import boto3
+import json
+import os
+
+
+def process_record(record, sns, no_relay_messages, relay_topic_arn=None):
+    """
+    Filters "nominal" messages and relays import ones to another SNS topic
+
+    :param record: SNS record from ElastiCache
+    :type record: dict
+    :param sns: boto3 SNS client
+    :param no_relay_messages: List of message types to relay
+    :param no_relay_topic_arn: ARN to relay unknown/critical messages to
+    :type relay_topic_arn: str|None
+    """
+    assert 'Sns' in record, \
+        "Record is not an event from SNS"
+
+    # Parse the message from SNS
+    raw_sns_record = record['Sns']
+    message = json.loads(raw_sns_record['Message'])
+
+    # Determine if we should relay this record or not
+    should_relay = False
+
+    for k in message.keys():
+        if k.lower() not in no_relay_messages:
+            # This is an important message
+            should_relay = True
+
+        # Break early if we should already be relaying the message
+        if should_relay:
+            break
+
+    if not should_relay:
+        # Don't bother relaying this message
+        return False
+
+    # Compose message subject for VictorOps topic
+    message_subject = ";".join([
+        "{} - {}".format(k, v)
+        for k, v in message.iteritems()
+    ])
+    print("Relaying message:\n" + json.dumps(message))
+
+    if not relay_topic_arn:
+        # Message SHOULD be relayed, but no relay topic ARN received
+        raise Exception("No relay ARN passed to relay message to: " + json.dumps(message))
+
+    sns.publish(
+        TopicArn=relay_topic_arn,
+        Subject=message_subject,
+        Message=json.dumps(message, indent=4))
+
+
+def lambda_handler(event, context):
+    """
+    Handles inbound SNS events from the ElastiCache service
+    """
+    assert 'Records' in event, \
+        "No event records key relayed"
+    assert len(event['Records']) > 0, \
+        "No event records relayed"
+
+    sns = boto3.client('sns')
+    relay_topic_arn = os.environ.get('RELAY_TOPIC', None)
+    no_relay_messages_json = json.loads(
+        '{"no_relay_messages": [' + os.environ.get('NO_RELAY_MESSAGES') + ']}'
+    )
+    no_relay_messages = no_relay_messages_json['no_relay_messages']
+
+    for record in event['Records']:
+        process_record(record, sns, no_relay_messages, relay_topic_arn)


### PR DESCRIPTION
- Filters out select message types which are provided by an environmental variable
- Relays message to another SNS topic & formatted for a VictorOps incident trigger