### PR TITLE
Fix instancecleanup permissions

### DIFF
--- a/instancecleanup/instancecleanup.json
+++ b/instancecleanup/instancecleanup.json
@@ -15,6 +15,7 @@
       "Sid": "",
       "Effect": "Allow",
       "Action": [
+        "ec2:DescribeInstanceAttribute",
         "ec2:DescribeInstances",
         "ec2:TerminateInstances"
       ],


### PR DESCRIPTION
With a semi-recent refactoring, the `ec2:DescribeInstanceAttribute` is now required.